### PR TITLE
Implement postboot procedure

### DIFF
--- a/tcl/airsense-info.tcl
+++ b/tcl/airsense-info.tcl
@@ -92,3 +92,13 @@ proc h {} {
 	echo "\tp        : print all values"
 	echo "\th        : show this help screen"
 }
+
+# ------------------------------------------------------------------
+# Faycal Kilalis Postboot fix
+
+proc postboot {} {
+    # resume execution at the reset vector
+    echo "Jumping to application…"
+    reset run
+}
+# ------------------------------------------------------------------


### PR DESCRIPTION
Implementation of the postboot procedures as required by the firmware flashing process.
This fixes issue [#68](https://github.com/osresearch/airbreak/issues/68)
